### PR TITLE
fix: semantic-release build_command type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ version_toml = ["pyproject.toml:project.version"]
 version_variables = ["chart/Chart.yaml:appVersion:tf"]
 branch = "main"
 changelog_file = "CHANGELOG.md"
-build_command = false
+build_command = ""
 tag_format = "v{version}"
 
 [project.urls]


### PR DESCRIPTION
## Summary

- Fix `build_command = false` (bool) to `build_command = ""` (string) in pyproject.toml — python-semantic-release v10 requires a string type

🤖 Generated with [Claude Code](https://claude.com/claude-code)